### PR TITLE
Make voting visual after reset

### DIFF
--- a/BadKevinBot.py
+++ b/BadKevinBot.py
@@ -30,138 +30,140 @@ databaseCursor = databaseConnection.cursor()
 
 
 # Database-based logic
-def query_database(input_table):  # Queries values from the SQL databse to return to the bot.
+def check_for_server_entry(input_server_id):
+    databaseCursor.execute(fr'SELECT server_id FROM global_stats WHERE server_id={input_server_id}')
+    if databaseCursor.fetchone() is None:
+        try:
+            databaseCursor.execute(fr'INSERT INTO global_stats (server_id, total_reset_amount, best_record, streak_average, last_wacko_message) VALUES ({input_server_id}, 0, 0, 0, "No messages found.")')
+            databaseConnection.commit()
+        except Exception as error:
+            raise fr'This server wasn\'t found in the database, and an error adding this server to the database occured: {error}'
+    else:
+        pass
+
+
+def query_database(input_table, input_server_id):
+
     try:
-        databaseCursor.execute(fr'SELECT current_record FROM {input_table}')
-        current_record_value = databaseCursor.fetchone()[0]  # fetchone returns tuple
-        if current_record_value is None:
-            current_record_value = 0
-
-        databaseCursor.execute(fr'SELECT best_record FROM {input_table}')
-        best_record_value = databaseCursor.fetchone()[0]
-        if best_record_value is None:
-            best_record_value = 0
-
-        databaseCursor.execute(fr'SELECT last_wacko_message FROM {input_table}')
-        last_wacko_message_value = databaseCursor.fetchone()[0]
-        if last_wacko_message_value is None:
-            last_wacko_message_value = 'none'
-
-        databaseCursor.execute(fr'SELECT streak_average FROM {input_table}')
-        streak_average_value = databaseCursor.fetchone()[0]
-        if streak_average_value is None:
-            streak_average_value = 0
-
-        databaseCursor.execute(fr'SELECT total_reset_amount FROM {input_table}')
-        total_reset_amount_value = databaseCursor.fetchone()[0]
-        if total_reset_amount_value is None:
-            total_reset_amount_value = 0
-
-        databaseCursor.execute(fr'SELECT channel_id FROM {input_table}')
+        databaseCursor.execute(fr'SELECT channel_id FROM {input_table} WHERE server_id={input_server_id}')
         channel_id_value = databaseCursor.fetchone()[0]
+        databaseCursor.execute(fr'SELECT total_reset_amount FROM {input_table} WHERE server_id={input_server_id}')
+        total_reset_amount_value = databaseCursor.fetchone()[0]
+        databaseCursor.execute(fr'SELECT best_record FROM {input_table} WHERE server_id={input_server_id}')
+        best_record_value = databaseCursor.fetchone()[0]
+        databaseCursor.execute(fr'SELECT streak_average FROM {input_table} WHERE server_id={input_server_id}')
+        streak_average_value = databaseCursor.fetchone()[0]
+        databaseCursor.execute(fr'SELECT last_wacko_message FROM {input_table} WHERE server_id={input_server_id}')
+        last_wacko_message_value = databaseCursor.fetchone()[0]
 
-        return best_record_value, current_record_value, last_wacko_message_value, streak_average_value, total_reset_amount_value, channel_id_value
+        return channel_id_value, total_reset_amount_value, best_record_value, streak_average_value, last_wacko_message_value
 
     except Exception as error:
-        print(f'An error occured: {error}')
+        print(f'An error occured where querying from table {input_table} for server {input_server_id}: {error}')
         return fr'There was an error while querying the database.'
 
 
-def update_current_record(input_table):
+def update_channel_id(input_table, input_server_id, input_channel_id):
     try:
-        databaseCursor.execute(fr'UPDATE {input_table} SET current_record = current_record + 1')
+        databaseCursor.execute(fr'UPDATE {input_table} SET channel_id = {input_channel_id} WHERE server_id={input_server_id}')
         databaseConnection.commit()
-        print(f'Added 1 to current_record in {input_table}')
-        return fr'Added 1 to Kevin\'s current record. Way to go!'
+        print(f'Changed channel_id in {input_table} to {input_channel_id} for server: {input_server_id}')
+        return fr'Updated the tracking channel to ID:{input_channel_id} for this server.'
 
     except Exception as error:
-        print(f'An error occured during an SQL update adding to current_record in {input_table}: {error}')
-        return fr'There was an error updating the current record. There may be an issue with the database.'
+        print(f'An error occured during an SQL update changing channel_id in {input_table} to {input_channel_id} in server: {input_server_id}: {error}')
+        return fr'An error occured during an SQL update changing channel_id to {input_channel_id}: {error}'
 
 
-def update_channel_id(input_table, input_channel_id):
+def reset_current_record(input_table, input_server_id, input_current_record_value):
     try:
-        databaseCursor.execute(fr'UPDATE {input_table} SET channel_id = {input_channel_id}')
+        databaseCursor.execute(fr'UPDATE {input_table} SET total_reset_amount = total_reset_amount + 1 WHERE server_id={input_server_id}')
+        print(input_current_record_value)
+        # update streak_average and best_record here later with input_current_record_value and math
         databaseConnection.commit()
-        print(f'Changed channel_id in {input_table} to {input_channel_id}')
-        return fr'Changed channel_id in {input_table} to {input_channel_id}'
-
-    except Exception as error:
-        print(
-            f'An error occured during an SQL update changing channel_id in {input_table} to {input_channel_id}: {error}')
-        return fr'An error occured during an SQL update changing channel_id in {input_table} to {input_channel_id}.'
-
-
-def reset_current_record(input_table):
-    try:
-        databaseCursor.execute(fr'UPDATE {input_table} SET current_record = 0')
-        databaseConnection.commit()
-        print(f'Reset current record in {input_table}.')
+        print(fr'Updated total and average for server ({input_server_id}) in table {input_table}.')
         return fr'Reset Kevin\'s current record to zero. Not upset, just disappointed.'
 
     except Exception as error:
-        print(f"An error occured during an SQL update: {error}")
-        return fr'There was an error resetting the current record. There may be an issue with the database.'
-
-
-# Slash command groups: These don't appear to work based on the documentation...
-setCommandGroup = discord.SlashCommandGroup('set', 'Administratively set options for your server.')
+        print(fr'An error occured during an SQL update for total and average for server ({input_server_id}) in table {input_table}: {error}')
+        return fr'There was an error resetting the records in the database: {error}'
 
 
 # Built-in slash commands:
-@bot.slash_command(description='Set the channel that receives name updates.', guild_ids=BadKevinBotID)
-async def set_channel_id(interaction: discord.Interaction, channel_name: discord.VoiceChannel):
-    channel_id = discord.utils.get(bot.get_all_channels(), name=f'{channel_name}').id
-    update_channel = update_channel_id('global_stats', channel_id)
-    await interaction.response.send_message(f'{update_channel}', ephemeral=True)
-
-
-@bot.slash_command(description='Get current Kevin stats.', guild_ids=BadKevinBotID)
+@bot.slash_command(description=fr'Get current Kevin stats.', guild_ids=BadKevinBotID)
 async def stats(context: discord.ApplicationContext):
+    server_id = context.guild.id
+    check_for_server_entry(server_id)
     embed = discord.Embed(
-        title='Kevin\'s current stats:',
+        title=fr'Kevin\'s current stats:',
         color=discord.Color.purple()
     )
-    stat_query = query_database('global_stats')
-    embed.add_field(name='Best Record', value=fr'{stat_query[0]}', inline=False)
-    embed.add_field(name='Current Record:', value=fr'{stat_query[1]}', inline=False)
+    stat_query = query_database('global_stats', server_id)
+    embed.add_field(name='Best Record', value=fr'{stat_query[2]}', inline=False)
     embed.add_field(name='Streak Average:', value=fr'{stat_query[3]}', inline=False)
-    embed.add_field(name='Total Resets:', value=fr'{stat_query[4]}', inline=False)
-    embed.add_field(name='Last Wacko Message:', value=fr'{stat_query[2]}', inline=False)
+    embed.add_field(name='Total Resets:', value=fr'{stat_query[1]}', inline=False)
+    embed.add_field(name='Last Wacko Message:', value=fr'{stat_query[4]}', inline=False)
     await context.respond(embed=embed)
+
+
+@bot.slash_command(description=fr'Set the voice channel that will be renamed to keep track of Kevin\'s current record.', guild_ids=BadKevinBotID)
+async def set_tracking_channel(interaction: discord.Interaction, channel_name: discord.VoiceChannel):
+    server_id = interaction.guild.id
+    check_for_server_entry(server_id)
+    channel_id = discord.utils.get(bot.get_all_channels(), name=f'{channel_name}').id
+    update_channel = update_channel_id('global_stats', server_id, channel_id)
+    await interaction.response.send_message(f'{update_channel}', ephemeral=True)
 
 
 @bot.slash_command(description='Advance Kevin 1 day.', guild_ids=BadKevinBotID)
 async def advance(interaction: discord.Interaction):
-    update_advance = update_current_record('global_stats')
-    await interaction.response.send_message(f'{update_advance}', ephemeral=True)
+    server_id = interaction.guild.id
+    check_for_server_entry(server_id)
+    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
+    channel_id = databaseCursor.fetchone()[0]
 
+    if channel_id is None:
+        await interaction.response.send_message(fr'The channel the bot needs to edit doesn\'t appear to be set. You can set it with the **\\set_tracking_channel command**', ephemeral=True)
+    else:
+        voice_channel = bot.get_channel(channel_id)
+        voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
+        voice_channel_update = voice_channel.name.replace(voice_channel_number, str(int(voice_channel_number)+1), 1)
 
-@bot.slash_command(description='Advance channel name.', guild_ids=BadKevinBotID)
-async def channel(interaction: discord.Interaction):
-    current_record_value = query_database('global_stats')[1]
-    current_channel_id = query_database('global_stats')[5]
-    voice_channel = discord.utils.get(bot.get_all_channels(), id=current_channel_id)
-
-    if voice_channel and isinstance(voice_channel, discord.VoiceChannel):  # Checks if channel exists
         try:
-            await update_channel_name(current_record_value)
-            await interaction.response.send_message(f'Updated count on channel.', ephemeral=True)
+            await voice_channel.edit(name=voice_channel_update)
+            print(fr'Successfully renamed channel {voice_channel.id} to {voice_channel_update}.')
+            await interaction.response.send_message(fr'Added 1 to Kevin\'s current record. Currently at {voice_channel_number} Way to go!', ephemeral=True)
 
         except Exception as error:
-            print(f'Failed to rename channel {voice_channel}: {error}')
-            await interaction.response.send_message(f'Failed to rename channel {voice_channel}.', ephemeral=True)
-    else:
-        print(f'Channel {voice_channel} was not found. Unable to update.')
-        await interaction.response.send_message(f'Channel {voice_channel} wasn\'t not found. Unable to update.',
-                                                ephemeral=True)
+            print(fr'Failed to rename channel {voice_channel.id} to {voice_channel.name}: {error}')
+            await interaction.response.send_message(
+                fr'Failed to rename channel {voice_channel.id} to {voice_channel.name}: {error}', ephemeral=True)
 
 
 @bot.slash_command(description='Reset the clock!', guild_ids=BadKevinBotID)
 async def reset(context: discord.ApplicationContext):
-    update_reset = reset_current_record('global_stats')
-    await reset_channel_name()
-    await context.respond(f'{update_reset}')
+    server_id = context.guild.id
+    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
+    channel_id = databaseCursor.fetchone()[0]
+
+    if channel_id is None:
+        await context.response.send_message(fr'The channel the bot needs to edit doesn\'t appear to be set. You can set it with the `\\set_tracking_channel command`', ephemeral=True)
+    else:
+        voice_channel = bot.get_channel(channel_id)
+        voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
+        voice_channel_reset = voice_channel.name.replace(voice_channel_number, '0', 1)
+
+        try:
+            await voice_channel.edit(name=voice_channel_reset)
+            print(fr'Successfully reset channel {voice_channel.id} to {voice_channel_reset}.')
+            await context.response.send_message(fr'Reset Kevin\'s current record. A graceful fall from {voice_channel_number}. We\'re not upset, just disappointed.', ephemeral=True)
+
+        except Exception as error:
+            print(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}')
+            await context.response.send_message(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}', ephemeral=True)
+
+        reset_current_record('global_stats', server_id, voice_channel_number)
+        # Probably move this function logic in here to later edit the reponse based on new records and such.
 
 
 # Reporting:
@@ -290,7 +292,26 @@ async def report(context: discord.ApplicationContext):
                 downvote_voter_array.append(voter)
                 new_downvote_value = int(vote_embed.fields[5].value.replace('`', '')) + 1
                 if new_downvote_value == 1:
-                    await reset_channel_name()
+                    server_id = interaction.guild.id
+                    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
+                    channel_id = databaseCursor.fetchone()[0]
+
+                    voice_channel = bot.get_channel(channel_id)
+                    voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
+                    voice_channel_reset = voice_channel.name.replace(voice_channel_number, '0', 1)
+
+                    try:
+                        await voice_channel.edit(name=voice_channel_reset)
+                        print(fr'Successfully reset channel {voice_channel.id} to {voice_channel_reset}.')
+                        await context.response.send_message(
+                            fr'Reset Kevin\'s current record. A graceful fall from {voice_channel_number}. We\'re not upset, just disappointed.',
+                            ephemeral=True)
+
+                    except Exception as error:
+                        print(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}')
+                        await context.response.send_message(
+                            fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}',
+                            ephemeral=True)
                 else:
                     pass
 
@@ -310,56 +331,36 @@ async def report(context: discord.ApplicationContext):
     await context.respond(embed=report_embed, ephemeral=True, view=report_view)
 
 
-# Discord-based embeds and logic
-async def update_channel_name(current_record_value):
-    channel_id = query_database('global_stats')[5]
-    voice_channel = bot.get_channel(channel_id)
-    print(voice_channel.name)
-    print(voice_channel.name)
-    new_name = f'[{current_record_value}] days since Kevin said something wacko.'
-
-    if voice_channel and isinstance(voice_channel, discord.VoiceChannel):
-        try:
-            await voice_channel.edit(name=new_name)
-            print(f'Successfully renamed channel {voice_channel.id} to {voice_channel.name}.')
-            return f'Successfully renamed channel {voice_channel.id} to {voice_channel.name}.'
-
-        except Exception as error:
-            print(f'Failed to rename channel: {error}')
-            return f'Failed to rename channel: {error}'
-    else:
-        print(f'Channel ID: {voice_channel.id}: was not found. Unable to update.')
-        return f'Channel ID: {voice_channel.id}: was not found. Unable to update.'
-
-
-async def reset_channel_name():
-    channel_id = query_database('global_stats')[5]
-    voice_channel = bot.get_channel(channel_id)
-
-    if voice_channel and isinstance(voice_channel, discord.VoiceChannel):
-        try:
-            await voice_channel.edit(name=f'[0] days since Kevin said something wacko.')
-            print(f'Successfully renamed channel {voice_channel}.')
-            return f'Successfully renamed channel {voice_channel}.'
-
-        except Exception as error:
-            print(f'Failed to rename channel: {error}')
-            return f'Failed to rename channel: {error}'
-    else:
-        print(f'Channel {voice_channel} was not found. Unable to update.')
-        return f'Channel {voice_channel} was not found. Unable to update.'
-
-
 # Simplified loop, eventually will use DateTime objects that can keep track of other changes such as reports.
 @tasks.loop(hours=24)
 async def daily_update():
-    update_current_record('global_stats')
-    print(f'Updated daily stats.')
+    databaseCursor.execute(fr'SELECT server_id FROM global_stats')
+    servers = databaseCursor.fetchall()
+    server_list = list(sum(servers, ()))
+    for server in server_list:
+        server_id = server
+        databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
+        channel_id = databaseCursor.fetchone()[0]
+
+        if channel_id is None:
+            pass
+        else:
+            voice_channel = bot.get_channel(channel_id)
+            voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
+            voice_channel_update = voice_channel.name.replace(voice_channel_number, str(int(voice_channel_number)+1), 1)
+
+            try:
+                await voice_channel.edit(name=voice_channel_update)
+                print(fr'Successfully renamed channel {voice_channel.id} to {voice_channel_update}.')
+
+            except Exception as error:
+                print(fr'Failed to rename channel {voice_channel.id} to {voice_channel.name}: {error}')
 
 
 @bot.event
 async def on_ready():
     print(f'Bot is ready. Logged in as {bot.user.name}')
+    daily_update.start()
 
 
 bot.run(clientSecret)

--- a/BadKevinBot.py
+++ b/BadKevinBot.py
@@ -1,9 +1,10 @@
 import os
 import re
-import discord
 import mysql.connector
 from dotenv import load_dotenv
+import discord
 from discord.ext import tasks
+
 
 # ---------- VARIABLES AND INFORMATION ----------
 # Load the environment file for protected Discord Bot information.
@@ -13,11 +14,10 @@ clientID = (os.environ.get('CLIENTID'))
 clientSecret = (os.environ.get('CLIENTSECRET'))
 sqlPassword = (os.environ.get('SQLPASSWORD'))
 BadKevinBotID = [1205001660145995776]
+kevin_author_id = 200696839639531523
 
 intents = discord.Intents.default()
 bot = discord.Bot()
-
-kevin_author_id = 200696839639531523
 
 databaseConnection = mysql.connector.connect(
     host='gamesnj409.bisecthosting.com',
@@ -30,8 +30,8 @@ databaseCursor = databaseConnection.cursor()
 
 
 # Database-based logic
-def check_for_server_entry(input_server_id):
-    databaseCursor.execute(fr'SELECT server_id FROM global_stats WHERE server_id={input_server_id}')
+def check_for_server_entry(input_server_id):  # This is a common function that ensures a server already has an entry with settings. If not it creates one with default settings.
+    databaseCursor.execute(fr'SELECT server_id FROM global_stats WHERE server_id = {input_server_id}')
     if databaseCursor.fetchone() is None:
         try:
             databaseCursor.execute(fr'INSERT INTO global_stats (server_id, total_reset_amount, best_record, streak_average, last_wacko_message) VALUES ({input_server_id}, 0, 0, 0, "No messages found.")')
@@ -45,15 +45,15 @@ def check_for_server_entry(input_server_id):
 def query_database(input_table, input_server_id):
 
     try:
-        databaseCursor.execute(fr'SELECT channel_id FROM {input_table} WHERE server_id={input_server_id}')
+        databaseCursor.execute(fr'SELECT channel_id FROM {input_table} WHERE server_id = {input_server_id}')
         channel_id_value = databaseCursor.fetchone()[0]
-        databaseCursor.execute(fr'SELECT total_reset_amount FROM {input_table} WHERE server_id={input_server_id}')
+        databaseCursor.execute(fr'SELECT total_reset_amount FROM {input_table} WHERE server_id = {input_server_id}')
         total_reset_amount_value = databaseCursor.fetchone()[0]
-        databaseCursor.execute(fr'SELECT best_record FROM {input_table} WHERE server_id={input_server_id}')
+        databaseCursor.execute(fr'SELECT best_record FROM {input_table} WHERE server_id = {input_server_id}')
         best_record_value = databaseCursor.fetchone()[0]
-        databaseCursor.execute(fr'SELECT streak_average FROM {input_table} WHERE server_id={input_server_id}')
+        databaseCursor.execute(fr'SELECT streak_average FROM {input_table} WHERE server_id = {input_server_id}')
         streak_average_value = databaseCursor.fetchone()[0]
-        databaseCursor.execute(fr'SELECT last_wacko_message FROM {input_table} WHERE server_id={input_server_id}')
+        databaseCursor.execute(fr'SELECT last_wacko_message FROM {input_table} WHERE server_id = {input_server_id}')
         last_wacko_message_value = databaseCursor.fetchone()[0]
 
         return channel_id_value, total_reset_amount_value, best_record_value, streak_average_value, last_wacko_message_value
@@ -65,7 +65,7 @@ def query_database(input_table, input_server_id):
 
 def update_channel_id(input_table, input_server_id, input_channel_id):
     try:
-        databaseCursor.execute(fr'UPDATE {input_table} SET channel_id = {input_channel_id} WHERE server_id={input_server_id}')
+        databaseCursor.execute(fr'UPDATE {input_table} SET channel_id = {input_channel_id} WHERE server_id = {input_server_id}')
         databaseConnection.commit()
         print(f'Changed channel_id in {input_table} to {input_channel_id} for server: {input_server_id}')
         return fr'Updated the tracking channel to ID:{input_channel_id} for this server.'
@@ -75,22 +75,8 @@ def update_channel_id(input_table, input_server_id, input_channel_id):
         return fr'An error occured during an SQL update changing channel_id to {input_channel_id}: {error}'
 
 
-def reset_current_record(input_table, input_server_id, input_current_record_value):
-    try:
-        databaseCursor.execute(fr'UPDATE {input_table} SET total_reset_amount = total_reset_amount + 1 WHERE server_id={input_server_id}')
-        print(input_current_record_value)
-        # update streak_average and best_record here later with input_current_record_value and math
-        databaseConnection.commit()
-        print(fr'Updated total and average for server ({input_server_id}) in table {input_table}.')
-        return fr'Reset Kevin\'s current record to zero. Not upset, just disappointed.'
-
-    except Exception as error:
-        print(fr'An error occured during an SQL update for total and average for server ({input_server_id}) in table {input_table}: {error}')
-        return fr'There was an error resetting the records in the database: {error}'
-
-
 # Built-in slash commands:
-@bot.slash_command(description=fr'Get current Kevin stats.', guild_ids=BadKevinBotID)
+@bot.slash_command(description=fr'Get current Kevin stats. [Work In Progress]', guild_ids=BadKevinBotID)
 async def stats(context: discord.ApplicationContext):
     server_id = context.guild.id
     check_for_server_entry(server_id)
@@ -103,7 +89,7 @@ async def stats(context: discord.ApplicationContext):
     embed.add_field(name='Streak Average:', value=fr'{stat_query[3]}', inline=False)
     embed.add_field(name='Total Resets:', value=fr'{stat_query[1]}', inline=False)
     embed.add_field(name='Last Wacko Message:', value=fr'{stat_query[4]}', inline=False)
-    await context.respond(embed=embed)
+    await context.respond(embed=embed, ephemeral=True)
 
 
 @bot.slash_command(description=fr'Set the voice channel that will be renamed to keep track of Kevin\'s current record.', guild_ids=BadKevinBotID)
@@ -112,223 +98,275 @@ async def set_tracking_channel(interaction: discord.Interaction, channel_name: d
     check_for_server_entry(server_id)
     channel_id = discord.utils.get(bot.get_all_channels(), name=f'{channel_name}').id
     update_channel = update_channel_id('global_stats', server_id, channel_id)
-    await interaction.response.send_message(f'{update_channel}', ephemeral=True)
-
-
-@bot.slash_command(description='Advance Kevin 1 day.', guild_ids=BadKevinBotID)
-async def advance(interaction: discord.Interaction):
-    server_id = interaction.guild.id
-    check_for_server_entry(server_id)
-    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
-    channel_id = databaseCursor.fetchone()[0]
-
-    if channel_id is None:
-        await interaction.response.send_message(fr'The channel the bot needs to edit doesn\'t appear to be set. You can set it with the **\\set_tracking_channel command**', ephemeral=True)
-    else:
-        voice_channel = bot.get_channel(channel_id)
-        voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
-        voice_channel_update = voice_channel.name.replace(voice_channel_number, str(int(voice_channel_number)+1), 1)
-
-        try:
-            await voice_channel.edit(name=voice_channel_update)
-            print(fr'Successfully renamed channel {voice_channel.id} to {voice_channel_update}.')
-            await interaction.response.send_message(fr'Added 1 to Kevin\'s current record. Currently at {voice_channel_number} Way to go!', ephemeral=True)
-
-        except Exception as error:
-            print(fr'Failed to rename channel {voice_channel.id} to {voice_channel.name}: {error}')
-            await interaction.response.send_message(
-                fr'Failed to rename channel {voice_channel.id} to {voice_channel.name}: {error}', ephemeral=True)
+    await interaction.response.send_message(f'{update_channel}', ephemeral=True, delete_after=60)
 
 
 @bot.slash_command(description='Reset the clock!', guild_ids=BadKevinBotID)
 async def reset(context: discord.ApplicationContext):
     server_id = context.guild.id
-    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
+    check_for_server_entry(server_id)
+    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id = {server_id}')
     channel_id = databaseCursor.fetchone()[0]
 
     if channel_id is None:
         await context.response.send_message(fr'The channel the bot needs to edit doesn\'t appear to be set. You can set it with the `\\set_tracking_channel command`', ephemeral=True)
     else:
         voice_channel = bot.get_channel(channel_id)
-        voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
-        voice_channel_reset = voice_channel.name.replace(voice_channel_number, '0', 1)
+        if len(re.findall(r'\d+', voice_channel.name)) <= 0:
+            await context.response.send_message(fr'The channel name: `{voice_channel.name}` doesn\'t appear to have a record (number) in it. Ensure there is a number to act as the record somewhere.', ephemeral=True)
+            print(fr'The channel name: `{voice_channel.name}` doesn\'t appear to have a record (number) in it. Ensure there is a number to act as the record somewhere.')
+        else:
+            current_record = re.findall(r'\d+', voice_channel.name)[0]
+            voice_channel_reset = voice_channel.name.replace(current_record, '0', 1)
 
-        try:
-            await voice_channel.edit(name=voice_channel_reset)
-            print(fr'Successfully reset channel {voice_channel.id} to {voice_channel_reset}.')
-            await context.response.send_message(fr'Reset Kevin\'s current record. A graceful fall from {voice_channel_number}. We\'re not upset, just disappointed.', ephemeral=True)
+            databaseCursor.execute(fr'UPDATE global_stats SET total_reset_amount = total_reset_amount + 1 WHERE server_id = {server_id}')
+            databaseConnection.commit()
+            databaseCursor.execute(fr'SELECT total_reset_amount FROM global_stats WHERE server_id = {server_id}')
+            total_reset_amount = databaseCursor.fetchone()[0]
+            databaseCursor.execute(fr'SELECT best_record FROM global_stats WHERE server_id = {server_id}')
+            best_record = databaseCursor.fetchone()[0]
+            databaseCursor.execute(fr'SELECT streak_average FROM global_stats WHERE server_id = {server_id}')
+            streak_average = databaseCursor.fetchone()[0]
 
-        except Exception as error:
-            print(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}')
-            await context.response.send_message(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}', ephemeral=True)
+            new_streak_average = round((int(streak_average) + int(current_record))/int(total_reset_amount))
+            databaseCursor.execute(fr'UPDATE global_stats SET streak_average = {new_streak_average} WHERE server_id = {server_id}')
+            databaseConnection.commit()
 
-        reset_current_record('global_stats', server_id, voice_channel_number)
-        # Probably move this function logic in here to later edit the reponse based on new records and such.
+            if int(best_record) <= int(current_record):
+                try:
+                    databaseCursor.execute(fr'UPDATE global_stats SET best_record = {current_record} WHERE server_id = {server_id}')
+                    databaseConnection.commit()
+
+                    await voice_channel.edit(name=voice_channel_reset)
+                    print(fr'Successfully reset channel {voice_channel.id} to {voice_channel_reset}.')
+
+                    await context.response.send_message(fr'Reset Kevin\'s current record. A graceful fall from `{current_record}`. At least you do have a new best record! We believe you can do better Kevin!')
+
+                except Exception as error:
+                    print(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}')
+                    await context.response.send_message(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}', ephemeral=True, delete_after=60)
+
+            else:
+                await voice_channel.edit(name=voice_channel_reset)
+                print(fr'Successfully reset channel {voice_channel.id} to {voice_channel_reset}.')
+                await context.response.send_message(fr'Reset Kevin\'s current record. A less than graceful fall from `{current_record}`. We\'re not upset, just disappointed.')
 
 
 # Reporting:
-@bot.slash_command(description='Report Kevin:', guild_ids=BadKevinBotID)
+@bot.slash_command(description='Report Kevin for crimes agains the server...', guild_ids=BadKevinBotID)
 async def report(context: discord.ApplicationContext):
-    report_embed = discord.Embed(
-        title='Report',
-        description='You are currently reporting Kevin for some wacko shit. Please select a recent message from below to start the reporting process.',
-        color=discord.Color.red()
-    )
+    server_id = context.guild.id
+    check_for_server_entry(server_id)
+    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id = {server_id}')
+    channel_id = databaseCursor.fetchone()[0]
 
-    select_options = []
-    messages_channel = bot.get_channel(context.channel_id)
-    messages = await messages_channel.history(limit=100).flatten()
-    for message in messages:
-        if message.author.id == kevin_author_id:
-            message_label = message.author.display_name[:24]
-            message_content_preview = message.content[:99]
-            message_id = message.id
-            select_options.append(
-                discord.SelectOption(
-                    label=f'{message_label}',
-                    value=f'{message_id}',
-                    description=f'{message_content_preview}'
-                )
+    if channel_id is None:
+        await context.response.send_message(fr'The channel the bot needs to edit doesn\'t appear to be set. The bot can\'t report correctly with out it. You can set it with the `\\set_tracking_channel command`', ephemeral=True)
+
+    else:
+        voice_channel = bot.get_channel(channel_id)
+        if len(re.findall(r'\d+', voice_channel.name)) <= 0:
+            await context.response.send_message(fr'The channel name: `{voice_channel.name}` doesn\'t appear to have a record (number) in it. Ensure there is a number to act as the record somewhere before reporting.', ephemeral=True)
+            print(fr'The channel name: `{voice_channel.name}` doesn\'t appear to have a record (number) in it. Ensure there is a number to act as the record somewhere.')
+
+        else:
+            report_embed = discord.Embed(
+                title='Report',
+                description='You are currently reporting Kevin for some wacko shit. Please select a recent message from below to start the reporting process.',
+                color=discord.Color.red()
             )
 
-    report_view = discord.ui.View()
+            select_options = []
+            messages_channel = bot.get_channel(context.channel_id)
+            messages = await messages_channel.history(limit=100).flatten()
+            for message in messages:
+                if message.author.id == kevin_author_id:
+                    message_label = message.author.display_name[:24]
+                    message_content_preview = message.content[:99]
+                    message_id = message.id
+                    select_options.append(
+                        discord.SelectOption(
+                            label=f'{message_label}',
+                            value=f'{message_id}',
+                            description=f'{message_content_preview}'
+                        )
+                    )
 
-    message_selection = discord.ui.Select(custom_id='Message Selection',
-                                          placeholder='The last few of Kevin\'s chat in this channel are below.',
-                                          options=select_options,
-                                          min_values=1,
-                                          max_values=1
-                                          )
+            report_view = discord.ui.View()
 
-    async def message_selection_callback(interaction: discord.Interaction):
-        for child in report_view.children:
-            if isinstance(child, discord.ui.Button) and child.label == 'Report':
-                child.disabled = False
-                break
+            message_selection = discord.ui.Select(custom_id='Message Selection',
+                                                  placeholder='The last few of Kevin\'s chat in this channel are below.',
+                                                  options=select_options,
+                                                  min_values=1,
+                                                  max_values=1
+                                                  )
 
-        for index, option in enumerate(message_selection.options):
-            if option.value == message_selection.values[0]:
-                message_selection.options[index].default = True
-            else:
-                message_selection.options[index].default = False
-        await interaction.response.edit_message(view=report_view)
+            async def message_selection_callback(interaction: discord.Interaction):
+                for child in report_view.children:
+                    if isinstance(child, discord.ui.Button) and child.label == 'Report':
+                        child.disabled = False
+                        break
 
-    message_selection.callback = message_selection_callback
-    report_view.add_item(message_selection)
+                for index, option in enumerate(message_selection.options):
+                    if option.value == message_selection.values[0]:
+                        message_selection.options[index].default = True
 
-    cancel_button = discord.ui.Button(label='Cancel', style=discord.ButtonStyle.grey, custom_id='Cancel Button')
+                    else:
+                        message_selection.options[index].default = False
 
-    async def cancel_button_callback(interaction: discord.Interaction):
-        report_view.disable_all_items()
-        cancel_embed = discord.Embed(
-            title='Report Cancelled',
-            description='User cancelled or timed out. No report was submitted.',
-            color=discord.Color.blue()
-        )
-        cancel_embed.set_footer(text='This message will disappear soon or can be dismissed.')
-        await interaction.response.edit_message(embed=cancel_embed, view=report_view)
+                await interaction.response.edit_message(view=report_view)
 
-    cancel_button.callback = cancel_button_callback
-    report_view.add_item(cancel_button)
+            message_selection.callback = message_selection_callback
+            report_view.add_item(message_selection)
 
-    report_button = discord.ui.Button(label='Report', style=discord.ButtonStyle.red, custom_id='Report Button',
-                                      disabled=True)
+            cancel_button = discord.ui.Button(label='Cancel', style=discord.ButtonStyle.grey, custom_id='Cancel Button')
 
-    async def report_button_callback(interaction: discord.Interaction):
-        report_view.disable_all_items()
-        embed_report = discord.Embed(
-            title='Report Submitted',
-            description='Your report should be visible below for all guild members to vote on below. Thank you for your service to this good Christian Discord.',
-            color=discord.Color.green(),
-        )
-        embed_report.set_footer(text='This message will disappear soon or can be dismissed.')
-        await interaction.response.edit_message(embed=embed_report, view=report_view)
+            async def cancel_button_callback(interaction: discord.Interaction):
+                report_view.disable_all_items()
+                cancel_embed = discord.Embed(
+                    title='Report Cancelled',
+                    description='User cancelled or timed out. No report was submitted.',
+                    color=discord.Color.blue()
+                )
+                cancel_embed.set_footer(text='This message will disappear soon or can be dismissed.')
 
-        vote_embed = discord.Embed(
-            title='Wacko Alert!',
-            description='Kevin has been reported for saying some wacko shit. Information regarding the offense is below.',
-            color=discord.Color.red()
-        )
-        message_content = await context.fetch_message(int(message_selection.values[0]))
-        vote_embed.set_thumbnail(url='https://i.imgflip.com/5kv6v1.png')
-        vote_embed.add_field(name='', value=' ', inline=False)
-        vote_embed.add_field(name=f'Message: {message_content.jump_url}', value=f'> {message_content.content}', inline=False)
-        vote_embed.add_field(name='', value=' ', inline=False)
-        vote_embed.add_field(name='', value='**Five wacko votes will result in a Kevin\'s counter being reset.**', inline=False)
-        vote_embed.add_field(name='Passes:', value='`0`', inline=True)
-        vote_embed.add_field(name='Wacko:', value='`0`', inline=True)
+                await interaction.response.edit_message(embed=cancel_embed, view=report_view)
 
-        vote_view = discord.ui.View()
+            cancel_button.callback = cancel_button_callback
+            report_view.add_item(cancel_button)
 
-        upvote_voter_array = []
-        downvote_voter_array = []
+            report_button = discord.ui.Button(label='Report', style=discord.ButtonStyle.red, custom_id='Report Button', disabled=True)
 
-        upvote_button = discord.ui.Button(label='Acceptable...', style=discord.ButtonStyle.green, emoji='🆗', custom_id='Upvote Button')
+            async def report_button_callback(interaction: discord.Interaction):
+                report_view.disable_all_items()
+                embed_report = discord.Embed(
+                    title='Report Submitted',
+                    description='Your report should be visible below for all guild members to vote on below. Thank you for your service to this good Christian Discord.',
+                    color=discord.Color.green(),
+                )
+                embed_report.set_footer(text='This message will disappear soon or can be dismissed.')
 
-        async def upvote_button_callback(interaction: discord.Interaction):
-            voter = interaction.message.author.id
-            if voter in upvote_voter_array:
-                upvote_voter_array.remove(voter)
-                new_upvote_value = int(vote_embed.fields[4].value.replace('`', '')) - 1
-            else:
-                upvote_voter_array.append(voter)
-                new_upvote_value = int(vote_embed.fields[4].value.replace('`', '')) + 1
+                await interaction.response.edit_message(embed=embed_report, view=report_view, delete_after=30)
 
-            vote_embed.set_field_at(index=4, name='Passes:', value=f'`{new_upvote_value}`', inline=True)
+                vote_embed = discord.Embed(
+                    title='Wacko Alert!',
+                    description='Kevin has been reported for saying some wacko shit. Information regarding the offense is below.',
+                    color=discord.Color.red()
+                )
+                message_content = await context.fetch_message(int(message_selection.values[0]))
+                vote_embed.set_thumbnail(url='https://i.imgflip.com/5kv6v1.png')
+                vote_embed.add_field(name='', value=' ', inline=False)
+                vote_embed.add_field(name=f'Message: {message_content.jump_url}', value=f'> {message_content.content}', inline=False)
+                vote_embed.add_field(name='', value=' ', inline=False)
+                vote_embed.add_field(name='', value='**Five wacko votes will result in a Kevin\'s counter being reset.**', inline=False)
+                vote_embed.add_field(name='Passes:', value='`0`', inline=True)
+                vote_embed.add_field(name='Wacko:', value='`0`', inline=True)
 
-            await interaction.response.edit_message(embed=vote_embed, view=vote_view)
+                vote_view = discord.ui.View()
 
-        upvote_button.callback = upvote_button_callback
-        vote_view.add_item(upvote_button)
+                upvote_button = discord.ui.Button(label='Acceptable...', style=discord.ButtonStyle.green, emoji='🆗', custom_id='Upvote Button')
 
-        downvote_button = discord.ui.Button(label='Wacko!', style=discord.ButtonStyle.red, emoji='😬', custom_id='Downvote Button')
+                upvote_voter_array = []
+                downvote_voter_array = []
+                report_complete_flag = False
 
-        async def downvote_button_callback(interaction: discord.Interaction):
-            voter = interaction.message.author.id
-            if voter in downvote_voter_array:
-                downvote_voter_array.remove(voter)
-                new_downvote_value = int(vote_embed.fields[5].value.replace('`', '')) - 1
-            else:
-                downvote_voter_array.append(voter)
-                new_downvote_value = int(vote_embed.fields[5].value.replace('`', '')) + 1
-                if new_downvote_value == 1:
-                    server_id = interaction.guild.id
-                    databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
-                    channel_id = databaseCursor.fetchone()[0]
+                async def upvote_button_callback(upvote_interaction: discord.Interaction):
+                    voter = upvote_interaction.message.author.id
+                    nonlocal upvote_voter_array
 
-                    voice_channel = bot.get_channel(channel_id)
-                    voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
-                    voice_channel_reset = voice_channel.name.replace(voice_channel_number, '0', 1)
+                    if voter in upvote_voter_array:
+                        upvote_voter_array.remove(voter)
+                        new_upvote_value = int(vote_embed.fields[4].value.replace('`', '')) - 1
 
-                    try:
-                        await voice_channel.edit(name=voice_channel_reset)
-                        print(fr'Successfully reset channel {voice_channel.id} to {voice_channel_reset}.')
-                        await context.response.send_message(
-                            fr'Reset Kevin\'s current record. A graceful fall from {voice_channel_number}. We\'re not upset, just disappointed.',
-                            ephemeral=True)
+                    else:
+                        upvote_voter_array.append(voter)
+                        new_upvote_value = int(vote_embed.fields[4].value.replace('`', '')) + 1
 
-                    except Exception as error:
-                        print(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}')
-                        await context.response.send_message(
-                            fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}',
-                            ephemeral=True)
-                else:
-                    pass
+                    vote_embed.set_field_at(index=4, name='Passes:', value=f'`{new_upvote_value}`', inline=True)
 
-            vote_embed.set_field_at(index=5, name='Wacko:', value=f'`{new_downvote_value}`', inline=True)
+                    await upvote_interaction.response.edit_message(embed=vote_embed, view=vote_view)
 
-            await interaction.response.edit_message(embed=vote_embed, view=vote_view)
+                upvote_button.callback = upvote_button_callback
+                vote_view.add_item(upvote_button)
 
-        downvote_button.callback = downvote_button_callback
-        vote_view.add_item(downvote_button)
+                downvote_button = discord.ui.Button(label='Wacko!', style=discord.ButtonStyle.red, emoji='😬', custom_id='Downvote Button')
 
-        await context.respond(embed=vote_embed, view=vote_view, ephemeral=True)
-        pass
+                async def downvote_button_callback(downvote_interaction: discord.Interaction):
+                    voter = downvote_interaction.message.author.id
+                    nonlocal downvote_voter_array
 
-    report_button.callback = report_button_callback
-    report_view.add_item(report_button)
+                    if voter in downvote_voter_array:
+                        downvote_voter_array.remove(voter)
+                        new_downvote_value = int(vote_embed.fields[5].value.replace('`', '')) - 1
 
-    await context.respond(embed=report_embed, ephemeral=True, view=report_view)
+                    else:
+                        downvote_voter_array.append(voter)
+                        new_downvote_value = int(vote_embed.fields[5].value.replace('`', '')) + 1
+                        nonlocal report_complete_flag
+
+                        if new_downvote_value == 1 and report_complete_flag is False:
+                            report_complete_flag = True
+
+                            current_record = re.findall(r'\d+', voice_channel.name)[0]
+                            voice_channel_reset = voice_channel.name.replace(current_record, '0', 1)
+
+                            databaseCursor.execute(fr'UPDATE global_stats SET total_reset_amount = total_reset_amount + 1 WHERE server_id = {server_id}')
+                            databaseConnection.commit()
+                            databaseCursor.execute(fr'SELECT total_reset_amount FROM global_stats WHERE server_id = {server_id}')
+                            total_reset_amount = databaseCursor.fetchone()[0]
+                            databaseCursor.execute(fr'SELECT best_record FROM global_stats WHERE server_id = {server_id}')
+                            best_record = databaseCursor.fetchone()[0]
+                            databaseCursor.execute(fr'SELECT streak_average FROM global_stats WHERE server_id = {server_id}')
+                            streak_average = databaseCursor.fetchone()[0]
+
+                            new_streak_average = round((int(streak_average) + int(current_record)) / int(total_reset_amount))
+                            databaseCursor.execute(fr'UPDATE global_stats SET streak_average = {new_streak_average} WHERE server_id = {server_id}')
+                            databaseConnection.commit()
+
+                            if int(best_record) <= int(current_record):
+                                try:
+                                    databaseCursor.execute(fr'UPDATE global_stats SET best_record = {current_record} WHERE server_id = {server_id}')
+                                    databaseConnection.commit()
+
+                                    vote_embed.set_field_at(index=3, name='', value=f'''```ansi
+[2;31m[1;31mThe server has spoken and Kevin has been found guilty![0m[2;31m[0m
+```
+Kevin\'s record has been reset. A graceful fall from `{current_record}`. At least he got a new record, we do believe you can do better though Kevin!''', inline=False)
+                                    vote_embed.set_image(url='https://alanlclack.blob.core.windows.net/alice-exe/discord/wackosmacko.png')
+
+                                    await voice_channel.edit(name=voice_channel_reset)
+                                    print(fr'Successfully reset channel based on votes {voice_channel.id} to {voice_channel_reset}.')
+
+                                except Exception as error:
+                                    print(fr'Failed to reset channel based on votes {voice_channel.id} to {voice_channel.name}: {error}')
+                                    await downvote_interaction.response.send_message(fr'Failed to reset channel {voice_channel.id} to {voice_channel.name}: {error}', ephemeral=True)
+
+                            else:
+                                await voice_channel.edit(name=voice_channel_reset)
+                                print(fr'Successfully reset channel {voice_channel.id} to {voice_channel_reset}.')
+
+                                vote_embed.set_field_at(index=3, name='', value=f'''```ansi
+[2;31m[1;31mThe server has spoken and Kevin has been found guilty![0m[2;31m[0m
+```
+Kevin\'s record has been reset. A less than graceful fall from `{current_record}`. We\'re not upset, just disappointed.''', inline=False)
+                                vote_embed.set_image(url='https://alanlclack.blob.core.windows.net/alice-exe/discord/wackosmacko.png')
+
+                        else:
+                            pass
+
+                    vote_embed.set_field_at(index=5, name='Wacko:', value=f'`{new_downvote_value}`', inline=True)
+
+                    await downvote_interaction.response.edit_message(embed=vote_embed, view=vote_view)
+
+                downvote_button.callback = downvote_button_callback
+                vote_view.add_item(downvote_button)
+
+                await context.respond(embed=vote_embed, view=vote_view)
+
+            report_button.callback = report_button_callback
+            report_view.add_item(report_button)
+
+            await context.respond(embed=report_embed, view=report_view, ephemeral=True)
 
 
 # Simplified loop, eventually will use DateTime objects that can keep track of other changes such as reports.
@@ -339,22 +377,34 @@ async def daily_update():
     server_list = list(sum(servers, ()))
     for server in server_list:
         server_id = server
-        databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id={server_id}')
+        databaseCursor.execute(fr'SELECT channel_id FROM global_stats WHERE server_id = {server_id}')
         channel_id = databaseCursor.fetchone()[0]
 
         if channel_id is None:
             pass
         else:
             voice_channel = bot.get_channel(channel_id)
-            voice_channel_number = re.findall(r'\d+', voice_channel.name)[0]
-            voice_channel_update = voice_channel.name.replace(voice_channel_number, str(int(voice_channel_number)+1), 1)
+            if len(re.findall(r'\d+', voice_channel.name)) <= 0:
+                print(fr'Skipping {voice_channel} due to having no numbers.')
+                pass
+            else:
+                current_record = re.findall(r'\d+', voice_channel.name)[0]
+                new_record = str(int(current_record) + 1)
+                voice_channel_update = voice_channel.name.replace(current_record, new_record, 1)
 
-            try:
-                await voice_channel.edit(name=voice_channel_update)
-                print(fr'Successfully renamed channel {voice_channel.id} to {voice_channel_update}.')
+                try:
+                    await voice_channel.edit(name=voice_channel_update)
+                    print(fr'Successfully daily updated channel {voice_channel.id} to {voice_channel_update}.')
+                    databaseCursor.execute(fr'SELECT best_record FROM global_stats WHERE server_id = {server_id}')
+                    best_record = databaseCursor.fetchone()[0]
+                    if int(best_record) < int(current_record):
+                        databaseCursor.execute(fr'UPDATE global_stats SET best_record = {new_record} WHERE server_id = {server_id}')
+                        databaseConnection.commit()
+                    else:
+                        pass
 
-            except Exception as error:
-                print(fr'Failed to rename channel {voice_channel.id} to {voice_channel.name}: {error}')
+                except Exception as error:
+                    print(fr'Failed to daily update channel {voice_channel.id} to {voice_channel.name}: {error}')
 
 
 @bot.event


### PR DESCRIPTION
Overhauled the database logic. Got rid of unnecessary functions that were more for testing.
Primary made voting visual after a full report.
The difficulty came from the fact interactions can only get one response, so its tricky to both edit an embed and send a message with the same interaction.reponse. Opted to just update the embed.